### PR TITLE
The update command's target version does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "./",
   "private": true,
   "scripts": {
-    "update": "npm install --save-dev @capacitor-community/sqlite@last --save vue-sqlite-hook@last",
+    "update": "npm install --save-dev @capacitor-community/sqlite@latest --save vue-sqlite-hook@latest",
     "serve": "npm run copysqlwasm && vue-cli-service serve",
     "build": "npm run copysqlwasm && vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",


### PR DESCRIPTION
## Problem:
When running `npm run update` the following error occurs. 
```bash
vue-sqlite-app-starter|main ⇒ npm run update

> vue-sqlite-app-starter@4.1.1 update
> npm install --save-dev @capacitor-community/sqlite@last --save vue-sqlite-hook@last

npm ERR! code ETARGET
npm ERR! notarget No matching version found for vue-sqlite-hook@last.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/[...]/.npm/cache/_logs/2023-01-14T11_41_06_660Z-debug-0.log
```

## Solution:
Changing version from `last` to `latest` removes the error and hopefully fetches the latest version. 